### PR TITLE
external force DATASTREAM_DICT key was incorrect

### DIFF
--- a/src/morse/builder/data.py
+++ b/src/morse/builder/data.py
@@ -421,7 +421,7 @@ MORSE_DATASTREAM_DICT = {
             "ros": 'morse.middleware.ros.force_torque.WrenchReader',
             }
         },
-    "morse.actuators.externalForce.ExternalForce": {
+    "morse.actuators.external_force.ExternalForce": {
         "default": {
             "socket": INTERFACE_DEFAULT_IN,
             "yarp": INTERFACE_DEFAULT_IN,


### PR DESCRIPTION
ExternalForce was not working with ros.
Turns out the datastream interface key for ExternalForce was incorrect: it is `external_force` instead of `externalForce` as the name of [python file](https://github.com/morse-simulator/morse/blob/master/src/morse/actuators/external_force.py) and as described [here](https://github.com/morse-simulator/morse/blob/86f3793afcdb0f9bf0eb26435ef04f0518ab1f6f/src/morse/builder/actuators.py#L330)